### PR TITLE
Updated default value for path_prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Next, add a new disk to your `filesystems.php` config:
     'key_file' => [], // optional: Array of data that substitutes the .json file (see below)
     'project_id' => env('GOOGLE_CLOUD_PROJECT_ID', 'your-project-id'), // optional: is included in key file
     'bucket' => env('GOOGLE_CLOUD_STORAGE_BUCKET', 'your-bucket'),
-    'path_prefix' => env('GOOGLE_CLOUD_STORAGE_PATH_PREFIX', null), // optional: /default/path/to/apply/in/bucket
+    'path_prefix' => env('GOOGLE_CLOUD_STORAGE_PATH_PREFIX', ''), // optional: /default/path/to/apply/in/bucket
     'storage_api_uri' => env('GOOGLE_CLOUD_STORAGE_API_URI', null), // see: Public URLs below
     'visibility' => 'public', // optional: public|private
     'metadata' => ['cacheControl'=> 'public,max-age=86400'], // optional: default metadata


### PR DESCRIPTION
Since second value for `GoogleCloudStorageAdapter` class requires string, default `path_prefix` of `null` is causing notices. 

![Screen Shot 2022-02-15 at 2 26 21 PM](https://user-images.githubusercontent.com/811685/154053125-c790f8f5-d86b-41fd-9477-cf13c5068da2.png)
![Screen Shot 2022-02-15 at 2 23 41 PM](https://user-images.githubusercontent.com/811685/154053135-639eff75-843a-4380-8c44-bd6e838f391a.png)


![f06bdrfictf31](https://user-images.githubusercontent.com/811685/154053212-b26a9547-a4f2-44f5-a9c8-fa62719f2c57.jpg)

