### PR TITLE
Make getBucket() method public

### DIFF
--- a/src/GoogleCloudStorageAdapter.php
+++ b/src/GoogleCloudStorageAdapter.php
@@ -60,7 +60,7 @@ class GoogleCloudStorageAdapter extends FilesystemAdapter
         return $this->getBucket()->object($this->prefixer->prefixPath($path))->signedUrl($expiration, $options);
     }
 
-    private function getBucket(): Bucket
+    public function getBucket(): Bucket
     {
         return $this->client->bucket(Arr::get($this->config, 'bucket'));
     }


### PR DESCRIPTION
Make the getBucket() method public, so we can call the generateSignedPostPolicyV4() method on the bucket outside the class:
`$bucket->generateSignedPostPolicyV4($objectName,$dateTime)`

https://cloud.google.com/storage/docs/xml-api/post-object-forms#php