### PR TITLE
Fix api endpoint configuration

### DIFF
--- a/src/GoogleCloudStorageServiceProvider.php
+++ b/src/GoogleCloudStorageServiceProvider.php
@@ -61,6 +61,10 @@ class GoogleCloudStorageServiceProvider extends ServiceProvider
             $options['projectId'] = $projectId;
         }
 
+        if ($apiEndpoint = Arr::get($config, 'apiEndpoint')) {
+            $options['apiEndpoint'] = $apiEndpoint;
+        }
+
         return new StorageClient($options);
     }
 
@@ -86,6 +90,10 @@ class GoogleCloudStorageServiceProvider extends ServiceProvider
 
         if ($projectId = Arr::get($config, 'projectId', Arr::get($config, 'project_id'))) {
             $config['projectId'] = $projectId;
+        }
+
+        if ($apiEndpoint = Arr::get($config, 'apiEndpoint', Arr::get($config, 'storage_api_uri'))) {
+            $config['apiEndpoint'] = $apiEndpoint;
         }
 
         return $config;


### PR DESCRIPTION
GCS-compatible storages or fake servers don't work because apiEndpoint option isn't passed into client

Also resolves #13 