### PR TITLE
Use 'url' config for the base public path

### DIFF
--- a/src/GoogleCloudStorageAdapter.php
+++ b/src/GoogleCloudStorageAdapter.php
@@ -40,8 +40,8 @@ class GoogleCloudStorageAdapter extends FilesystemAdapter
     {
         $apiEndpoint = rtrim(Rest::DEFAULT_API_ENDPOINT, '/').'/'.ltrim(Arr::get($this->config, 'bucket'), '/');
 
-        if (isset($this->config['apiEndpoint'])) {
-            $apiEndpoint = $this->config['apiEndpoint'];
+        if (isset($this->config['url'])) {
+            $apiEndpoint = $this->config['url'];
         }
 
         return $this->concatPathToUrl($apiEndpoint, $this->prefixer->prefixPath($path));


### PR DESCRIPTION
In our production environment, we use custom domains for the GCS buckets. Unfortunately, using the `apiEndpoint` configuration variable (only for the `$file->url()`, aka only the display part), it gives the following error:
```xml
<?xml version='1.0' encoding='UTF-8'?><Error><Code>InvalidAuthentication</Code><Message>The provided authentication header is invalid.</Message><Details>Cannot use OAuth Authorization header with form POST.</Details></Error>
```

Replacing it with `url` in the config allows to use a different setting when we only want to use a different domain for the public url, while still using the regular `DEFAULT_API_ENDPOINT = 'https://storage.googleapis.com';` for the upload.

In this PR, I added a new configuration variable `url` which is only used for the generation of the link.