### PR TITLE
fix incorrect usage of storageApiUri / apiEndpoint config

### DIFF
--- a/src/GoogleCloudStorageAdapter.php
+++ b/src/GoogleCloudStorageAdapter.php
@@ -38,13 +38,13 @@ class GoogleCloudStorageAdapter extends FilesystemAdapter
      */
     public function url($path)
     {
-        $storageApiUrl = rtrim(Rest::DEFAULT_API_ENDPOINT, '/').'/'.ltrim(Arr::get($this->config, 'bucket'), '/');
+        $storageApiUri = rtrim(Rest::DEFAULT_API_ENDPOINT, '/').'/'.ltrim(Arr::get($this->config, 'bucket'), '/');
 
-        if (isset($this->config['storageApiUrl'])) {
-            $storageApiUrl = $this->config['storageApiUrl'];
+        if (isset($this->config['storageApiUri'])) {
+            $storageApiUri = $this->config['storageApiUri'];
         }
 
-        return $this->concatPathToUrl($storageApiUrl, $this->prefixer->prefixPath($path));
+        return $this->concatPathToUrl($storageApiUri, $this->prefixer->prefixPath($path));
     }
 
     /**
@@ -57,8 +57,8 @@ class GoogleCloudStorageAdapter extends FilesystemAdapter
      */
     public function temporaryUrl($path, $expiration, array $options = [])
     {
-        if (isset($this->config['storageApiUrl'])) {
-            $options['bucketBoundHostname'] = $this->config['storageApiUrl'];
+        if (isset($this->config['storageApiUri'])) {
+            $options['bucketBoundHostname'] = $this->config['storageApiUri'];
         }
         return $this->getBucket()->object($this->prefixer->prefixPath($path))->signedUrl($expiration, $options);
     }

--- a/src/GoogleCloudStorageAdapter.php
+++ b/src/GoogleCloudStorageAdapter.php
@@ -38,13 +38,13 @@ class GoogleCloudStorageAdapter extends FilesystemAdapter
      */
     public function url($path)
     {
-        $apiEndpoint = rtrim(Rest::DEFAULT_API_ENDPOINT, '/').'/'.ltrim(Arr::get($this->config, 'bucket'), '/');
+        $storageApiUrl = rtrim(Rest::DEFAULT_API_ENDPOINT, '/').'/'.ltrim(Arr::get($this->config, 'bucket'), '/');
 
-        if (isset($this->config['apiEndpoint'])) {
-            $apiEndpoint = $this->config['apiEndpoint'];
+        if (isset($this->config['storageApiUrl'])) {
+            $storageApiUrl = $this->config['storageApiUrl'];
         }
 
-        return $this->concatPathToUrl($apiEndpoint, $this->prefixer->prefixPath($path));
+        return $this->concatPathToUrl($storageApiUrl, $this->prefixer->prefixPath($path));
     }
 
     /**
@@ -57,6 +57,9 @@ class GoogleCloudStorageAdapter extends FilesystemAdapter
      */
     public function temporaryUrl($path, $expiration, array $options = [])
     {
+        if (isset($this->config['storageApiUrl'])) {
+            $options['bucketBoundHostname'] = $this->config['storageApiUrl'];
+        }
         return $this->getBucket()->object($this->prefixer->prefixPath($path))->signedUrl($expiration, $options);
     }
 

--- a/src/GoogleCloudStorageServiceProvider.php
+++ b/src/GoogleCloudStorageServiceProvider.php
@@ -60,7 +60,7 @@ class GoogleCloudStorageServiceProvider extends ServiceProvider
         if ($projectId = Arr::get($config, 'projectId')) {
             $options['projectId'] = $projectId;
         }
-
+        
         if ($apiEndpoint = Arr::get($config, 'apiEndpoint')) {
             $options['apiEndpoint'] = $apiEndpoint;
         }
@@ -92,8 +92,12 @@ class GoogleCloudStorageServiceProvider extends ServiceProvider
             $config['projectId'] = $projectId;
         }
 
-        if ($apiEndpoint = Arr::get($config, 'apiEndpoint', Arr::get($config, 'storage_api_uri'))) {
+        if ($apiEndpoint = Arr::get($config, 'apiEndpoint')) {
             $config['apiEndpoint'] = $apiEndpoint;
+        }
+
+        if ($storageApiUrl = Arr::get($config, 'storage_api_uri')) {
+            $config['storageApiUrl'] = $storageApiUrl;
         }
 
         return $config;

--- a/src/GoogleCloudStorageServiceProvider.php
+++ b/src/GoogleCloudStorageServiceProvider.php
@@ -60,7 +60,7 @@ class GoogleCloudStorageServiceProvider extends ServiceProvider
         if ($projectId = Arr::get($config, 'projectId')) {
             $options['projectId'] = $projectId;
         }
-        
+
         if ($apiEndpoint = Arr::get($config, 'apiEndpoint')) {
             $options['apiEndpoint'] = $apiEndpoint;
         }
@@ -96,8 +96,8 @@ class GoogleCloudStorageServiceProvider extends ServiceProvider
             $config['apiEndpoint'] = $apiEndpoint;
         }
 
-        if ($storageApiUrl = Arr::get($config, 'storage_api_uri')) {
-            $config['storageApiUrl'] = $storageApiUrl;
+        if ($storageApiUri = Arr::get($config, 'storage_api_uri')) {
+            $config['storageApiUri'] = $storageApiUri;
         }
 
         return $config;


### PR DESCRIPTION
apiEndpoint was used as both apiEndpoint and storage_api_uri, this commit separates them.

The storage_api_uri config is used to change the URL of accessing objects, not the API calls.  
ApiEndpoint is used to change the actual rest API endpoint of the storageClient. I have not found a use-case to change the apiEndpoint, but this PR leaves it up to the user to change it or not.

Fixes #25

With this PR we're able to use `bucketBoundHostnames` again by setting the `storage_api_uri` config:

```php
'gcs' => [
    'driver' => 'gcs',
    'key_file_path' => env('GOOGLE_CLOUD_KEY_FILE', null), // optional: /path/to/service-account.json
    'key_file' => [], // optional: Array of data that substitutes the .json file (see below)
    'project_id' => env('GOOGLE_CLOUD_PROJECT_ID', 'your-project-id'), // optional: is included in key file
    'bucket' => env('GOOGLE_CLOUD_STORAGE_BUCKET', 'your-bucket'),
    'path_prefix' => env('GOOGLE_CLOUD_STORAGE_PATH_PREFIX', ''), // optional: /default/path/to/apply/in/bucket
    'storage_api_uri' => env('GOOGLE_CLOUD_STORAGE_API_URI', 'https://cdn.example.org'), // see: Public URLs below
    'apiEndpoint' => env('GOOGLE_CLOUD_STORAGE_API_ENDPOINT', null), // set storageClient apiEndpoint
    'visibility' => 'public', // optional: public|private
    'metadata' => ['cacheControl'=> 'public,max-age=86400'], // optional: default metadata
],
```

And generate the correct `url()` and `temporaryUrl()` for example: https://cdn.example.org/cats.jpeg instead of https://storage.googleapis.com/your-bucket/cats.jpeg.

A good default config would be:

```php
'gcs' => [
    'driver' => 'gcs',
    'key_file_path' => env('GOOGLE_CLOUD_KEY_FILE', null), // optional: /path/to/service-account.json
    'key_file' => [], // optional: Array of data that substitutes the .json file (see below)
    'project_id' => env('GOOGLE_CLOUD_PROJECT_ID', 'your-project-id'), // optional: is included in key file
    'bucket' => env('GOOGLE_CLOUD_STORAGE_BUCKET', 'your-bucket'),
    'path_prefix' => env('GOOGLE_CLOUD_STORAGE_PATH_PREFIX', ''), // optional: /default/path/to/apply/in/bucket
    'storage_api_uri' => env('GOOGLE_CLOUD_STORAGE_API_URI', null), // see: Public URLs below
    'apiEndpoint' => env('GOOGLE_CLOUD_STORAGE_API_ENDPOINT', null), // set storageClient apiEndpoint
    'visibility' => 'public', // optional: public|private
    'metadata' => ['cacheControl'=> 'public,max-age=86400'], // optional: default metadata
],
```