### PR TITLE
feat: create temporaryUploadUrl method

### DIFF
--- a/src/GoogleCloudStorageAdapter.php
+++ b/src/GoogleCloudStorageAdapter.php
@@ -57,6 +57,23 @@ class GoogleCloudStorageAdapter extends FilesystemAdapter
         return $this->getBucket()->object($this->prefixer->prefixPath($path))->signedUrl($expiration, $options);
     }
 
+    /**
+     * Get a temporary upload URL for the file at the given path.
+     *
+     * @param  string  $path
+     * @param  \DateTimeInterface  $expiration
+     * @param  array  $options
+     * @return string
+     */
+    public function temporaryUploadUrl($path, $expiration, array $options = [])
+    {
+        if (isset($this->config['storageApiUri'])) {
+            $options['bucketBoundHostname'] = $this->config['storageApiUri'];
+        }
+
+        return $this->getBucket()->object($this->prefixer->prefixPath($path))->beginSignedUploadSession($options);
+    }
+
     public function getClient(): StorageClient
     {
         return $this->client;


### PR DESCRIPTION
Hey,

Laravel recently added the `temporaryUploadUrl` to the AwsS3V3Adapter (https://github.com/laravel/framework/pull/45753/)
This PR adds the same method for Google Cloud Storage.

This method can be used when you want to allow users to upload large files.

It generates a presigned upload url that you can use to upload a file with a `PUT` request.

```php
$url = Storage::disk('gcs')->temporaryUploadUrl($path, $expiration, array $options = []);
```
And then you can for eg send the file with your frontend by using Javascript:
```js
axios.put('url presigned', binary).then(...)
```
