### PR TITLE
add missing providesTemporaryUrls method

### DIFF
--- a/src/GoogleCloudStorageAdapter.php
+++ b/src/GoogleCloudStorageAdapter.php
@@ -83,4 +83,14 @@ class GoogleCloudStorageAdapter extends FilesystemAdapter
     {
         return $this->client->bucket(Arr::get($this->config, 'bucket'));
     }
+
+    /**
+     * Determine if temporary URLs can be generated.
+     *
+     * @return bool
+     */
+    public function providesTemporaryUrls(): bool
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
In order to solve the issue in [https://github.com/spatie/laravel-google-cloud-storage/issues/61](url)

I added the method providesTemporaryUrls() to the adapter. 