### PR TITLE
Fixes #78 - Fix generating url when storage api url is missing

### DIFF
--- a/src/GoogleCloudStorageAdapter.php
+++ b/src/GoogleCloudStorageAdapter.php
@@ -31,8 +31,11 @@ class GoogleCloudStorageAdapter extends FilesystemAdapter
      */
     public function url($path)
     {
-        $storageApiUri = $this->config['storageApiUri']
-            ?? rtrim(Rest::DEFAULT_API_ENDPOINT, '/').'/'.ltrim(Arr::get($this->config, 'bucket'), '/');
+        $storageApiUri = rtrim(Rest::DEFAULT_API_ENDPOINT, '/').'/'.ltrim(Arr::get($this->config, 'bucket'), '/');
+
+        if ($this->config['storageApiUri']) {
+            $storageApiUri = $this->config['storageApiUri'];
+        }
 
         return $this->concatPathToUrl($storageApiUri, $this->prefixer->prefixPath($path));
     }
@@ -47,7 +50,7 @@ class GoogleCloudStorageAdapter extends FilesystemAdapter
      */
     public function temporaryUrl($path, $expiration, array $options = [])
     {
-        if (! empty($this->config['storageApiUri'])) {
+        if ($this->config['storageApiUri']) {
             $options['bucketBoundHostname'] = $this->config['storageApiUri'];
         }
 
@@ -64,7 +67,7 @@ class GoogleCloudStorageAdapter extends FilesystemAdapter
      */
     public function temporaryUploadUrl($path, $expiration, array $options = [])
     {
-        if (! empty($this->config['storageApiUri'])) {
+        if ($this->config['storageApiUri']) {
             $options['bucketBoundHostname'] = $this->config['storageApiUri'];
         }
 


### PR DESCRIPTION
This will make the adapter consistent with the logic of `prepareConfig` from version 2.2.3.
https://github.com/spatie/laravel-google-cloud-storage/blob/2.2.3/src/GoogleCloudStorageServiceProvider.php#L102

In 2.2.3 the `storageApiUri` was only set if `storage_api_uri` was not falsy, since 2.2.4 it's always set if `storage_api_uri` is set.

Fixes #78