### PR TITLE
Improve Google Cloud Storage URL generation logic using bucket name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to `laravel-google-cloud-storage` will be documented in this file.
 
+## 2.4.0 - 2025-03-04
+
+### What's Changed
+
+* Fix url method using bucket name and storageApiUri due to Rest::DEFAULT_API_ENDPOINT is deprecated by @neoformalex in https://github.com/spatie/laravel-google-cloud-storage/pull/91
+
+### New Contributors
+
+* @neoformalex made their first contribution in https://github.com/spatie/laravel-google-cloud-storage/pull/91
+
+**Full Changelog**: https://github.com/spatie/laravel-google-cloud-storage/compare/2.3.1...2.4.0
+
 ## 2.3.1 - 2025-02-24
 
 ### What's Changed

--- a/src/GoogleCloudStorageAdapter.php
+++ b/src/GoogleCloudStorageAdapter.php
@@ -31,10 +31,15 @@ class GoogleCloudStorageAdapter extends FilesystemAdapter
      */
     public function url($path)
     {
-        $storageApiUri = rtrim(Rest::DEFAULT_API_ENDPOINT, '/').'/'.ltrim(Arr::get($this->config, 'bucket'), '/');
+        // Get the storage API URI from the configuration trim the trailing slash
+        $storageApiUri = rtrim(Arr::get($this->config, 'storageApiUri'), '/');
 
-        if (Arr::get($this->config, 'storageApiUri')) {
-            $storageApiUri = Arr::get($this->config, 'storageApiUri');
+        // Get the bucket name from the configuration
+        $bucketName = Arr::get($this->config, 'bucket');
+
+        // Construct the URL using the bucket name
+        if ($bucketName) {
+            $storageApiUri = "{$storageApiUri}/{$bucketName}";
         }
 
         return $this->concatPathToUrl($storageApiUri, $this->prefixer->prefixPath($path));


### PR DESCRIPTION
Google Cloud PHP package depricates `DEFAULT_API_ENDPOINT` and uses bucket name from the configuration.