### PR TITLE
fix: missing import Spatie\GoogleCloudStorage\Rest

### DIFF
--- a/src/GoogleCloudStorageAdapter.php
+++ b/src/GoogleCloudStorageAdapter.php
@@ -3,6 +3,7 @@
 namespace Spatie\GoogleCloudStorage;
 
 use Google\Cloud\Storage\Bucket;
+use Google\Cloud\Storage\Connection\Rest;
 use Google\Cloud\Storage\StorageClient;
 use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Support\Arr;


### PR DESCRIPTION
This PR addresses the issue described in [#105](https://github.com/spatie/laravel-google-cloud-storage/issues/105)