### PR TITLE
Fix creating gcs disk in laravel v13

### DIFF
--- a/src/GoogleCloudStorageServiceProvider.php
+++ b/src/GoogleCloudStorageServiceProvider.php
@@ -15,10 +15,12 @@ class GoogleCloudStorageServiceProvider extends ServiceProvider
 {
     public function boot()
     {
-        Storage::extend('gcs', function ($_app, $config) {
-            $config = $this->prepareConfig($config);
-            $client = $this->createClient($config);
-            $adapter = $this->createAdapter($client, $config);
+        $provider = $this;
+
+        Storage::extend('gcs', function ($_app, $config) use ($provider) {
+            $config = $provider->prepareConfig($config);
+            $client = $provider->createClient($config);
+            $adapter = $provider->createAdapter($client, $config);
 
             return new GoogleCloudStorageAdapter(
                 new Flysystem($adapter, $config),
@@ -29,7 +31,7 @@ class GoogleCloudStorageServiceProvider extends ServiceProvider
         });
     }
 
-    protected function createAdapter(StorageClient $client, array $config): FlysystemGoogleCloudStorageAdapter
+    public function createAdapter(StorageClient $client, array $config): FlysystemGoogleCloudStorageAdapter
     {
         $bucket = $client->bucket(Arr::get($config, 'bucket'));
 
@@ -49,7 +51,7 @@ class GoogleCloudStorageServiceProvider extends ServiceProvider
         return new FlysystemGoogleCloudStorageAdapter($bucket, $pathPrefix, $visibilityHandler, $defaultVisibility);
     }
 
-    protected function createClient(array $config): StorageClient
+    public function createClient(array $config): StorageClient
     {
         $options = [];
 
@@ -72,7 +74,7 @@ class GoogleCloudStorageServiceProvider extends ServiceProvider
         return new StorageClient($options);
     }
 
-    protected function prepareConfig(array $config): array
+    public function prepareConfig(array $config): array
     {
         // Google's SDK expects camelCase keys, but we can use snake_case in the config.
         foreach ($config as $key => $value) {

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -1,5 +1,0 @@
-<?php
-
-it('can run a basic test', function () {
-    expect(true)->toBeTrue();
-});

--- a/tests/GoogleCloudStorageServiceProviderTest.php
+++ b/tests/GoogleCloudStorageServiceProviderTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Support\Facades\Storage;
+use Spatie\GoogleCloudStorage\GoogleCloudStorageAdapter;
+
+it('can create a gcs disk', function () {
+    $disk = Storage::build([
+        'driver' => 'gcs',
+        'root' => fake()->uuid(),
+        'bucket' => fake()->word(),
+    ]);
+
+    Storage::set('gcs', $disk);
+
+    expect(Storage::disk('gcs'))->toBeInstanceOf(GoogleCloudStorageAdapter::class);
+});


### PR DESCRIPTION
When using this package in Laravel v13, it is not possible to create a gcs disk, as `$this` in the extend closure is not the service provider anymore (see https://github.com/laravel/framework/pull/57173). This PR fixes that. I also added a test.